### PR TITLE
fix: move "browser" map to the top of the exports

### DIFF
--- a/lib/decoder.js
+++ b/lib/decoder.js
@@ -1,6 +1,6 @@
 // @ts-ignore
 import varint from 'varint'
-import { CID } from 'multiformats'
+import CID from 'multiformats/cid'
 import * as Digest from 'multiformats/hashes/digest'
 // @ts-ignore
 import { decode as decodeDagCbor } from '@ipld/dag-cbor'

--- a/package.json
+++ b/package.json
@@ -60,16 +60,16 @@
   },
   "exports": {
     ".": {
-      "import": "./car.js",
-      "browser": "./car-browser.js"
+      "browser": "./car-browser.js",
+      "import": "./car.js"
     },
     "./reader": {
-      "import": "./lib/reader.js",
-      "browser": "./lib/reader-browser.js"
+      "browser": "./lib/reader-browser.js",
+      "import": "./lib/reader.js"
     },
     "./indexed-reader": {
-      "import": "./lib/indexed-reader.js",
-      "browser": "./lib/indexed-reader-browser.js"
+      "browser": "./lib/indexed-reader-browser.js",
+      "import": "./lib/indexed-reader.js"
     },
     "./indexer": {
       "import": "./lib/indexer.js"

--- a/package.json
+++ b/package.json
@@ -55,7 +55,7 @@
   },
   "dependencies": {
     "@ipld/dag-cbor": "^2.0.3",
-    "multiformats": "^4.4.1",
+    "multiformats": "^4.6.1",
     "varint": "^6.0.0"
   },
   "exports": {


### PR DESCRIPTION
[order](https://nodejs.org/api/packages.html#packages_conditional_exports) matters for these, some bundlers will strictly match in the order that they are encountered.

Ref: mikeal/ipjs#9