### PR TITLE
chore: make examples work

### DIFF
--- a/.github/workflows/mikeals-workflow.yml
+++ b/.github/workflows/mikeals-workflow.yml
@@ -5,6 +5,7 @@ jobs:
     name: Build & Test
     runs-on: ubuntu-latest
     strategy:
+      fail-fast: false
       matrix:
         node-version: [12.x, 14.x, 16.x]
     steps:

--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,5 @@ package-lock.json
 node_modules/
 .nyc_output/
 coverage/
-example.car
 build/
 dist/

--- a/README.md
+++ b/README.md
@@ -78,6 +78,13 @@ See the [examples](./examples) directory for more.
 class represents a discrete set of functionality. You should select the classes
 that make the most sense for your use-case.
 
+Please be aware that `@ipld/car` **does not validate** that block data matches
+the paired CIDs when reading a CAR. See the
+[verify-car.js](./examples/verify-car.js) example for one possible approach to
+validating blocks as they are read. Any CID verification requires that the hash
+function that was used to generate the CID be available, the CAR format does
+not restrict the allowable multihashes.
+
 ### [`CarReader`](#CarReader)
 
 The basic `CarReader` class is consumed via:

--- a/README.md
+++ b/README.md
@@ -25,8 +25,8 @@ See also:
 import fs from 'fs'
 import { Readable } from 'stream'
 import { CarReader, CarWriter } from '@ipld/car'
-import raw from 'multiformats/codecs/raw'
-import CID from 'multiformats/cid'
+import * as raw from 'multiformats/codecs/raw'
+import { CID } from 'multiformats/cid'
 import { sha256 } from 'multiformats/hashes/sha2'
 
 async function example () {
@@ -69,6 +69,8 @@ Will output:
 ```
 Retrieved [random meaningless bytes] from example.car with CID [bafkreihwkf6mtnjobdqrkiksr7qhp6tiiqywux64aylunbvmfhzeql2coa]
 ```
+
+See the [examples](./examples) directory for more.
 
 ## Usage
 

--- a/examples/.gitignore
+++ b/examples/.gitignore
@@ -1,3 +1,4 @@
 # ignore output from the examples
 example.car
 baf*
+Qm*

--- a/examples/.gitignore
+++ b/examples/.gitignore
@@ -1,0 +1,3 @@
+# ignore output from the examples
+example.car
+baf*

--- a/examples/dump-car.js
+++ b/examples/dump-car.js
@@ -1,12 +1,5 @@
 #!/usr/bin/env node
 
-// This example requires these additional dependencies:
-//   - @ipld/dag-pb
-//   - @ipld/dag-json
-// And needs to be run as a "module" which either means a package.json with
-//   `"type": "module"`
-// or the file needs to be renamed `example.mjs`.
-
 // Take a .car file and dump its contents into one file per block, with the
 // filename being the CID of that block.
 // Also prints a DAG-JSON form of the block and its CID to stdout.

--- a/examples/dump-car.js
+++ b/examples/dump-car.js
@@ -16,9 +16,8 @@ import { CarBlockIterator } from '@ipld/car/iterator'
 import * as dagCbor from '@ipld/dag-cbor'
 import * as dagPb from '@ipld/dag-pb'
 import * as dagJson from '@ipld/dag-json'
-import { codec } from 'multiformats/codecs/codec'
-import raw from 'multiformats/codecs/raw'
-import json from 'multiformats/codecs/json'
+import * as raw from 'multiformats/codecs/raw'
+import * as json from 'multiformats/codecs/json'
 
 if (!process.argv[2]) {
   console.log('Usage: example-dump-car.js <path/to/car>')
@@ -26,9 +25,9 @@ if (!process.argv[2]) {
 }
 
 const codecs = {
-  [dagCbor.code]: codec(dagCbor),
-  [dagPb.code]: codec(dagPb),
-  [dagJson.code]: codec(dagJson),
+  [dagCbor.code]: dagCbor,
+  [dagPb.code]: dagPb,
+  [dagJson.code]: dagJson,
   [raw.code]: raw,
   [json.code]: json
 }

--- a/examples/package.json
+++ b/examples/package.json
@@ -1,0 +1,25 @@
+{
+  "name": "@ipld/car-examples",
+  "version": "0.0.0-dev",
+  "description": "How to use the Content Addressable aRchive format reader and writer",
+  "main": "example.js",
+  "type": "module",
+  "scripts": {
+    "start": "node round-trip.js",
+    "round-trip": "node round-trip.js",
+    "verify": "node verify-car.js",
+    "dump": "node dump-car.js"
+  },
+  "author": "Rod <rod@vagg.org> (http://r.va.gg/)",
+  "license": "(Apache-2.0 AND MIT)",
+  "dependencies": {
+    "@ipld/car": "file:..",
+    "@ipld/dag-cbor": "^5.0.0",
+    "@ipld/dag-json": "^5.0.0",
+    "@ipld/dag-pb": "^1.1.0",
+    "@multiformats/blake2": "^0.0.0",
+    "@types/varint": "^6.0.0",
+    "multiformats": "^7.0.0",
+    "varint": "^6.0.0"
+  }
+}

--- a/examples/package.json
+++ b/examples/package.json
@@ -4,11 +4,13 @@
   "description": "How to use the Content Addressable aRchive format reader and writer",
   "main": "example.js",
   "type": "module",
+  "private": true,
   "scripts": {
     "start": "node round-trip.js",
     "round-trip": "node round-trip.js",
     "verify": "node verify-car.js",
-    "dump": "node dump-car.js"
+    "dump": "node dump-car.js",
+    "test": "npm install && node test-examples.js"
   },
   "author": "Rod <rod@vagg.org> (http://r.va.gg/)",
   "license": "(Apache-2.0 AND MIT)",

--- a/examples/round-trip.js
+++ b/examples/round-trip.js
@@ -1,10 +1,5 @@
 #!/usr/bin/env node
 
-// This example needs to be run as a "module" which either means a package.json
-// with
-//   `"type": "module"`
-// or the file needs to be renamed `example.mjs`.
-
 // Create a simple .car file with a single block and that block's CID as the
 // single root. Then read the .car and fetch the block again.
 

--- a/examples/round-trip.js
+++ b/examples/round-trip.js
@@ -11,8 +11,8 @@
 import fs from 'fs'
 import { Readable } from 'stream'
 import { CarReader, CarWriter } from '@ipld/car'
-import raw from 'multiformats/codecs/raw'
-import CID from 'multiformats/cid'
+import * as raw from 'multiformats/codecs/raw'
+import { CID } from 'multiformats/cid'
 import { sha256 } from 'multiformats/hashes/sha2'
 
 async function example () {

--- a/examples/test-examples.js
+++ b/examples/test-examples.js
@@ -1,0 +1,73 @@
+import assert from 'assert'
+import { promisify } from 'util'
+import { execFile } from 'child_process'
+import { promises as fsPromises } from 'fs'
+
+const { unlink, stat } = fsPromises
+
+const goCarCids = [
+  'bafkreidbxzk2ryxwwtqxem4l3xyyjvw35yu4tcct4cqeqxwo47zhxgxqwq',
+  'bafkreiebzrnroamgos2adnbpgw5apo3z4iishhbdx77gldnbk57d4zdio4',
+  'bafkreifw7plhl6mofk6sfvhnfh64qmkq73oeqwl6sloru6rehaoujituke',
+  'bafyreidj5idub6mapiupjwjsyyxhyhedxycv4vihfsicm2vt46o7morwlm',
+  'bafyreihyrpefhacm6kkp4ql6j6udakdit7g3dmkzfriqfykhjw6cad5lrm',
+  'QmdwjhxpxzcMsR3qUuj7vUL8pbA7MgR3GAxWi2GLHjsKCT',
+  'QmNX6Tffavsya4xgBi2VJQnSuqy9GsxongxZZ9uZBqp16d',
+  'QmWXZxVQ9yZfhQxLD35eDR8LiMRsYtHxYqTFCBbJoiJVys']
+
+async function cleanGoCarDump () {
+  return Promise.all(goCarCids.map((c) => unlink(c)))
+}
+
+async function runExample (name, args = []) {
+  return promisify(execFile)(process.execPath, [`${name}.js`].concat(args))
+}
+
+runExample('round-trip').then(({ stdout, stderr }) => {
+  assert.strictEqual(stderr, '')
+  assert.strictEqual(stdout, 'Retrieved [random meaningless bytes] from example.car with CID [bafkreihwkf6mtnjobdqrkiksr7qhp6tiiqywux64aylunbvmfhzeql2coa]\n')
+  console.log('\u001b[32m✔\u001b[39m [example] round-trip')
+}).then(async () => {
+  await runExample('verify-car', ['example.car']).then(({ stdout, stderr }) => {
+    assert.strictEqual(stderr, '')
+    assert.strictEqual(stdout, 'Verified 1 block(s) in example.car\n')
+    console.log('\u001b[32m✔\u001b[39m [example] verify-car example.car')
+  })
+}).then(async () => {
+  await runExample('verify-car', ['../test/go.car']).then(({ stdout, stderr }) => {
+    assert.strictEqual(stderr, '')
+    assert.strictEqual(stdout, 'Verified 8 block(s) in ../test/go.car\n')
+    console.log('\u001b[32m✔\u001b[39m [example] verify-car ../test/go.car')
+  })
+}).then(async () => {
+  try {
+    await cleanGoCarDump()
+  } catch (err) {} // failure is expected, this is just a prep
+  await runExample('dump-car', ['../test/go.car']).then(async ({ stdout, stderr }) => {
+    assert.strictEqual(stderr, '')
+    assert.strictEqual(stdout,
+`bafyreihyrpefhacm6kkp4ql6j6udakdit7g3dmkzfriqfykhjw6cad5lrm [dag-cbor]
+'{"link":{"/":"QmNX6Tffavsya4xgBi2VJQnSuqy9GsxongxZZ9uZBqp16d"},"name":"blip"}'
+QmNX6Tffavsya4xgBi2VJQnSuqy9GsxongxZZ9uZBqp16d [dag-pb]
+'{"Links":[{"Hash":{"/":"bafkreifw7plhl6mofk6sfvhnfh64qmkq73oeqwl6sloru6rehaoujituke"},"Name":"bear","Tsize":4},{"Hash":{"/":"QmWXZxVQ9yZfhQxLD35eDR8LiMRsYtHxYqTFCBbJoiJVys"},"Name":"second","Tsize":149}]}'
+bafkreifw7plhl6mofk6sfvhnfh64qmkq73oeqwl6sloru6rehaoujituke [raw]
+'{"0":99,"1":99,"2":99,"3":99}'
+QmWXZxVQ9yZfhQxLD35eDR8LiMRsYtHxYqTFCBbJoiJVys [dag-pb]
+'{"Links":[{"Hash":{"/":"bafkreiebzrnroamgos2adnbpgw5apo3z4iishhbdx77gldnbk57d4zdio4"},"Name":"dog","Tsize":4},{"Hash":{"/":"QmdwjhxpxzcMsR3qUuj7vUL8pbA7MgR3GAxWi2GLHjsKCT"},"Name":"first","Tsize":51}]}'
+bafkreiebzrnroamgos2adnbpgw5apo3z4iishhbdx77gldnbk57d4zdio4 [raw]
+'{"0":98,"1":98,"2":98,"3":98}'
+QmdwjhxpxzcMsR3qUuj7vUL8pbA7MgR3GAxWi2GLHjsKCT [dag-pb]
+'{"Links":[{"Hash":{"/":"bafkreidbxzk2ryxwwtqxem4l3xyyjvw35yu4tcct4cqeqxwo47zhxgxqwq"},"Name":"cat","Tsize":4}]}'
+bafkreidbxzk2ryxwwtqxem4l3xyyjvw35yu4tcct4cqeqxwo47zhxgxqwq [raw]
+'{"0":97,"1":97,"2":97,"3":97}'
+bafyreidj5idub6mapiupjwjsyyxhyhedxycv4vihfsicm2vt46o7morwlm [dag-cbor]
+'{"link":null,"name":"limbo"}'
+`)
+    assert.strictEqual((await Promise.all(goCarCids.map((c) => stat(c)))).map((s) => s.isFile()).filter(Boolean).length, goCarCids.length)
+    await cleanGoCarDump()
+    console.log('\u001b[32m✔\u001b[39m [example] dump-car ../test/go.car')
+  })
+}).catch((err) => {
+  console.error(err.stack)
+  process.exit(1)
+})

--- a/examples/verify-car.js
+++ b/examples/verify-car.js
@@ -17,9 +17,8 @@ import { CarBlockIterator } from '@ipld/car/iterator'
 import * as dagCbor from '@ipld/dag-cbor'
 import * as dagPb from '@ipld/dag-pb'
 import * as dagJson from '@ipld/dag-json'
-import { codec } from 'multiformats/codecs/codec'
-import raw from 'multiformats/codecs/raw'
-import json from 'multiformats/codecs/json'
+import * as raw from 'multiformats/codecs/raw'
+import * as json from 'multiformats/codecs/json'
 import { sha256 } from 'multiformats/hashes/sha2'
 import { from as hasher } from 'multiformats/hashes/hasher'
 import { blake2b256 } from '@multiformats/blake2/blake2b'
@@ -32,9 +31,9 @@ if (!process.argv[2]) {
 }
 
 const codecs = {
-  [dagCbor.code]: codec(dagCbor),
-  [dagPb.code]: codec(dagPb),
-  [dagJson.code]: codec(dagJson),
+  [dagCbor.code]: dagCbor,
+  [dagPb.code]: dagPb,
+  [dagJson.code]: dagJson,
   [raw.code]: raw,
   [json.code]: json
 }

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
   "scripts": {
     "build": "npm run build:js && npm run build:types",
     "build:js": "ipjs build --tests --main && npm run build:copy",
-    "build:copy": "cp -a tsconfig.json *.js *.ts lib/ test/ dist/",
+    "build:copy": "cp -a tsconfig.json *.js *.ts lib/ test/ examples/ dist/",
     "build:types": "npm run build:copy && cd dist && tsc --build",
     "prepublishOnly": "npm run build",
     "publish": "ipjs publish",
@@ -19,7 +19,7 @@
     "test:cjs": "rm -rf dist && npm run build && cp test/go.car dist/cjs/node-test/ && mocha dist/cjs/node-test/test-*.js && mocha dist/cjs/node-test/node-test-*.js && npm run test:cjs:browser",
     "test:node": "hundreds mocha test/test-*.js test/node-test-*.js",
     "test:cjs:browser": "polendina --cleanup dist/cjs/browser-test/test-*.js",
-    "test": "npm run lint && npm run test:node && npm run test:cjs",
+    "test": "npm run lint && npm run test:node && npm run test:cjs && npm run test --prefix examples/",
     "coverage": "c8 --reporter=html --reporter=text mocha test/test-*.js && npx st -d coverage -p 8888",
     "docs": "jsdoc4readme --readme --description-only lib/reader*.js lib/indexed-reader.js lib/iterator.js lib/indexer.js lib/writer.js"
   },

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -40,7 +40,7 @@
     "node_modules",
     "esm",
     "cjs",
-    "example*.js"
+    "examples"
   ],
   "compileOnSave": false
 }


### PR DESCRIPTION
- Move examples to their own directory and give them all the packge.json they need to be runnable.
- Fix imports since some things got moved around in multiformats
- Update readme and fix imports in example

License: MIT
Signed-off-by: Oli Evans <oli@tableflip.io>