### PR TITLE
fix: fix dist/examples packaging for publish

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
   "scripts": {
     "build": "npm run build:js && npm run build:types",
     "build:js": "ipjs build --tests --main && npm run build:copy",
-    "build:copy": "cp -a tsconfig.json *.js *.ts lib/ test/ examples/ dist/",
+    "build:copy": "mkdir -p dist/examples/ && cp -a tsconfig.json *.js *.ts lib/ test/ dist/ && cp examples/*.* dist/examples/",
     "build:types": "npm run build:copy && cd dist && tsc --build",
     "prepublishOnly": "npm run build",
     "publish": "ipjs publish",


### PR DESCRIPTION
publish failing because it's copying node_modules as well

Ref: https://github.com/ipld/js-car/runs/2518452165