### PR TITLE
fix: check header object and reject invalid headers & versions

### DIFF
--- a/lib/decoder.js
+++ b/lib/decoder.js
@@ -39,7 +39,23 @@ export async function readHeader (reader) {
   const length = await readVarint(reader)
   const header = await reader.exactly(length)
   reader.seek(length)
-  return decodeDagCbor(header)
+  const block = decodeDagCbor(header)
+  if (block == null || Array.isArray(block) || typeof block !== 'object') {
+    throw new Error('Invalid CAR header format')
+  }
+  if (block.version !== 1) {
+    if (typeof block.version === 'string') {
+      throw new Error(`Invalid CAR version: "${block.version}"`)
+    }
+    throw new Error(`Invalid CAR version: ${block.version}`)
+  }
+  if (!Array.isArray(block.roots)) {
+    throw new Error('Invalid CAR header format')
+  }
+  if (Object.keys(block).filter((p) => p !== 'roots' && p !== 'version').length) {
+    throw new Error('Invalid CAR header format')
+  }
+  return block
   /* c8 ignore next 2 */
   // Node.js 12 c8 bug
 }

--- a/test/test-errors.js
+++ b/test/test-errors.js
@@ -1,6 +1,22 @@
 /* eslint-env mocha */
+import { bytes } from 'multiformats'
+import { encode as cbEncode } from '@ipld/dag-cbor'
+import { encode as vEncode } from 'varint'
 import { CarReader } from '@ipld/car/reader'
 import { carBytes, assert } from './common.js'
+
+/**
+ * @param {any} block
+ * @returns {Uint8Array}
+ */
+function makeHeader (block) {
+  const u = cbEncode(block)
+  const l = vEncode(u.length)
+  const u2 = new Uint8Array(u.length + l.length)
+  u2.set(l, 0)
+  u2.set(u, l.length)
+  return u2
+}
 
 describe('Misc errors', () => {
   const buf = carBytes.slice()
@@ -14,5 +30,47 @@ describe('Misc errors', () => {
       name: 'Error',
       message: 'Unexpected CID version (0)'
     })
+  })
+
+  it('bad version', async () => {
+    // quick sanity check that makeHeader() works properly!
+    const buf2 = bytes.fromHex('0aa16776657273696f6e02')
+    // {version:2} - fixed string, likely to be used by CARv2 to escape header parsing rules
+    assert.strictEqual(bytes.toHex(makeHeader({ version: 2 })), '0aa16776657273696f6e02')
+    await assert.isRejected(CarReader.fromBytes(buf2), Error, 'Invalid CAR version: 2')
+  })
+
+  it('bad header', async () => {
+    // sanity check, this should be fine
+    let buf2 = makeHeader({ version: 1, roots: [] })
+    await assert.isFulfilled(CarReader.fromBytes(buf2))
+
+    // no 'version' array
+    buf2 = makeHeader({ roots: [] })
+    await assert.isRejected(CarReader.fromBytes(buf2), Error, 'Invalid CAR version: undefined')
+
+    // bad 'version' type
+    buf2 = makeHeader({ version: '1', roots: [] })
+    await assert.isRejected(CarReader.fromBytes(buf2), Error, 'Invalid CAR version: "1"')
+
+    // no 'roots' array
+    buf2 = makeHeader({ version: 1 })
+    await assert.isRejected(CarReader.fromBytes(buf2), Error, 'Invalid CAR header format')
+
+    // bad 'roots' type
+    buf2 = makeHeader({ version: 1, roots: {} })
+    await assert.isRejected(CarReader.fromBytes(buf2), Error, 'Invalid CAR header format')
+
+    // extraneous properties
+    buf2 = makeHeader({ version: 1, roots: [], blip: true })
+    await assert.isRejected(CarReader.fromBytes(buf2), Error, 'Invalid CAR header format')
+
+    // not an object
+    buf2 = makeHeader([1, []])
+    await assert.isRejected(CarReader.fromBytes(buf2), Error, 'Invalid CAR header format')
+
+    // not an object
+    buf2 = makeHeader(null)
+    await assert.isRejected(CarReader.fromBytes(buf2), Error, 'Invalid CAR header format')
   })
 })


### PR DESCRIPTION
Current version doesn't really check the header object is valid and it doesn't look at the version, but it should be strict, as per spec.

Also included in this is an explicit check for `0aa16776657273696f6e02` (`<length>{version:2}`) as per https://github.com/ipld/specs/pull/248#issuecomment-833141588 so it can be used as a CARv2 escape - if we end up using this string as a modifier for CARv2 we can at least get proper errors out of this if it encounters a newer format.

Doing this as a semver-patch since we're within spec and I doubt there are any CARs out there without a proper `{version:1, roots:[...]}` header.