### PR TITLE
fix: build types from source instead of generated files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ node_modules/
 coverage/
 build/
 dist/
+types/

--- a/package.json
+++ b/package.json
@@ -11,8 +11,8 @@
   "scripts": {
     "build": "npm run build:js && npm run build:types",
     "build:js": "ipjs build --tests --main && npm run build:copy",
-    "build:copy": "mkdir -p dist/examples/ && cp -a tsconfig.json *.js *.ts lib/ test/ dist/ && cp examples/*.* dist/examples/",
-    "build:types": "npm run build:copy && cd dist && tsc --build",
+    "build:copy": "mkdir -p dist/examples/ && cp -a tsconfig.json *.js *.ts lib test examples dist/",
+    "build:types": "tsc --build && mv types dist",
     "prepublishOnly": "npm run build",
     "publish": "ipjs publish",
     "lint": "standard",

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
   "scripts": {
     "build": "npm run build:js && npm run build:types",
     "build:js": "ipjs build --tests --main && npm run build:copy",
-    "build:copy": "mkdir -p dist/examples/ && cp -a tsconfig.json *.js *.ts lib test examples dist/",
+    "build:copy": "mkdir -p dist/examples/ && cp -a tsconfig.json *.js *.ts lib test dist/ && cp examples/*.* dist/examples/",
     "build:types": "tsc --build && mv types dist",
     "prepublishOnly": "npm run build",
     "publish": "ipjs publish",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -38,10 +38,8 @@
   },
   "exclude": [
     "node_modules",
-    "esm",
-    "cjs",
-    "examples",
-    "index.js"
+    "dist",
+    "examples"
   ],
   "compileOnSave": false
 }


### PR DESCRIPTION
This module copies everything into the `dist` folder then builds types from there.  `multiformats` builds types from the source, then copies moves the `types` folder into `dist`.  The latter seems more predictable and means things like https://github.com/mikeal/ipjs/pull/14 don't trip it up.