### PR TITLE
fix: handle zero-byte chunks on decode, don't write zero-byte chunks on encode

### DIFF
--- a/lib/decoder.js
+++ b/lib/decoder.js
@@ -217,7 +217,7 @@ export function bytesReader (bytes) {
  * reusable reader for streams and files, we just need a way to read an
  * additional chunk (of some undetermined size) and a way to close the
  * reader when finished
- * @param {() => Promise<Uint8Array>} readChunk
+ * @param {() => Promise<Uint8Array|null>} readChunk
  * @returns {BytesReader}
  */
 export function chunkReader (readChunk /*, closer */) {
@@ -231,7 +231,7 @@ export function chunkReader (readChunk /*, closer */) {
     const bufa = [currentChunk.subarray(offset)]
     while (have < length) {
       const chunk = await readChunk()
-      if (chunk.length === 0) {
+      if (chunk == null) {
         break
       }
       /* c8 ignore next 8 */
@@ -300,7 +300,7 @@ export function asyncIterableReader (asyncIterable) {
   async function readChunk () {
     const next = await iterator.next()
     if (next.done) {
-      return new Uint8Array(0)
+      return null
     }
     return next.value
     /* c8 ignore next 2 */

--- a/lib/encoder.js
+++ b/lib/encoder.js
@@ -49,7 +49,10 @@ function createEncoder (writer) {
       const { cid, bytes } = block
       await writer.write(new Uint8Array(varint.encode(cid.bytes.length + bytes.length)))
       await writer.write(cid.bytes)
-      await writer.write(bytes)
+      if (bytes.length) {
+        // zero-length blocks are valid, but it'd be safer if we didn't write them
+        await writer.write(bytes)
+      }
     },
 
     /**

--- a/test/test-reader.js
+++ b/test/test-reader.js
@@ -1,6 +1,10 @@
 /* eslint-env mocha */
 
 import { CarReader } from '@ipld/car/reader'
+import { CarWriter } from '@ipld/car/writer'
+import * as Block from 'multiformats/block'
+import { sha256 } from 'multiformats/hashes/sha2'
+import * as raw from 'multiformats/codecs/raw'
 import { carBytes, makeIterable, assert } from './common.js'
 import {
   verifyRoots,
@@ -80,6 +84,31 @@ describe('CarReader fromIterable()', () => {
     await verifyGet(reader)
     await verifyBlocks(reader.blocks())
     await verifyCids(reader.cids())
+  })
+
+  it('handle zero-byte chunks', async () => {
+    // write 3 blocks, the middle one has zero bytes - this is a valid dag-pb form
+    // so it's important that we can handle it .. also we may just be dealing with
+    // an asynciterator that provides zero-length chunks
+    const { writer, out } = await CarWriter.create([])
+    const b1 = await Block.encode({ value: Uint8Array.from([0, 1, 2]), hasher: sha256, codec: raw })
+    writer.put(b1)
+    const b2 = await Block.encode({ value: Uint8Array.from([]), hasher: sha256, codec: raw })
+    writer.put(b2)
+    const b3 = await Block.encode({ value: Uint8Array.from([3, 4, 5]), hasher: sha256, codec: raw })
+    writer.put(b3)
+    const closePromise = writer.close()
+    const reader = await CarReader.fromIterable(out) // read from the writer
+    const b1a = await reader.get(b1.cid)
+    assert.isDefined(b1a)
+    assert.deepStrictEqual(b1a && Array.from(b1a.bytes), [0, 1, 2])
+    const b2a = await reader.get(b2.cid)
+    assert.isDefined(b2a)
+    assert.deepStrictEqual(b2a && Array.from(b2a.bytes), [])
+    const b3a = await reader.get(b3.cid)
+    assert.isDefined(b3a)
+    assert.deepStrictEqual(b3a && Array.from(b3a.bytes), [3, 4, 5])
+    await closePromise
   })
 
   it('bad argument', async () => {


### PR DESCRIPTION
@jimpick I'm pretty sure this should resolve whatever residual problems you might be experiencing.

Attacking it in two ways:

1. On `decode()`: don't treat zero-byte chunks as an end-of-stream signal (!!)
2. On `encode()`: don't write out zero-byte chunks, since we don't need to and we may be dealing with a dodgy asynciterable consumer that sees zero-byte chunks as an end-of-stream signal

I've got a simplified form of your test case in here but it's piping from a `CarWriter` directly into a `CarReader` with no intermediary and without the fix it's got the same symptoms you've reported—third block doesn't exist.

Care to help with a quick review and 👍?