### PR TITLE
Clean up and expand examples

### DIFF
--- a/examples/car-to-fixture.js
+++ b/examples/car-to-fixture.js
@@ -1,0 +1,69 @@
+#!/usr/bin/env node
+
+// Take a .car file and dump its contents to stdout as a single DAG-JSON format
+// block. The format is standardised for describing CAR fixtures at
+// https://ipld.io/specs/transport/car/fixture/
+
+import fs from 'fs/promises'
+import { CarReader } from '@ipld/car/reader'
+import { CarIndexer } from '@ipld/car/indexer'
+import * as dagCbor from '@ipld/dag-cbor'
+import * as dagPb from '@ipld/dag-pb'
+import * as dagJson from '@ipld/dag-json'
+import * as raw from 'multiformats/codecs/raw'
+import * as json from 'multiformats/codecs/json'
+
+if (!process.argv[2]) {
+  console.log('Usage: dump-car.js <path/to/car>')
+  process.exit(1)
+}
+
+const codecs = {
+  [dagCbor.code]: dagCbor,
+  [dagPb.code]: dagPb,
+  [dagJson.code]: dagJson,
+  [raw.code]: raw,
+  [json.code]: json
+}
+
+function decode (cid, bytes) {
+  if (!codecs[cid.code]) {
+    throw new Error(`Unknown codec code: 0x${cid.code.toString(16)}`)
+  }
+  return codecs[cid.code].decode(bytes)
+}
+
+async function run () {
+  const bytes = await fs.readFile(process.argv[2])
+  // this is not the most optimal way to get both an index and a reader,
+  // nor is reading in the bytes into memory necessarily the best thing
+  // to be doing, but this is fine for small files and where efficiency
+  // isn't critical
+  const indexer = await CarIndexer.fromBytes(bytes)
+  const reader = await CarReader.fromBytes(bytes)
+  const fixture = {
+    header: {
+      roots: await reader.getRoots(),
+      version: reader.version
+    },
+    blocks: []
+  }
+  let i = 0
+  for await (const blockIndex of indexer) {
+    fixture.blocks[i] = blockIndex
+    const block = await reader.get(blockIndex.cid)
+    fixture.blocks[i].content = decode(blockIndex.cid, block.bytes)
+    i++
+  }
+  const json = new TextDecoder().decode(dagJson.encode(fixture))
+  if (process.argv.includes('--pretty')) {
+    console.log(JSON.stringify(JSON.parse(json), null, 2))
+  } else {
+    console.log(json)
+  }
+}
+
+run().catch((err) => {
+  console.error(err)
+  process.exit(1)
+})

--- a/examples/car-to-fixture.js
+++ b/examples/car-to-fixture.js
@@ -4,7 +4,7 @@
 // block. The format is standardised for describing CAR fixtures at
 // https://ipld.io/specs/transport/car/fixture/
 
-import fs from 'fs/promises'
+import fs from 'fs'
 import { CarReader } from '@ipld/car/reader'
 import { CarIndexer } from '@ipld/car/indexer'
 import * as dagCbor from '@ipld/dag-cbor'
@@ -34,7 +34,7 @@ function decode (cid, bytes) {
 }
 
 async function run () {
-  const bytes = await fs.readFile(process.argv[2])
+  const bytes = await fs.promises.readFile(process.argv[2])
   // this is not the most optimal way to get both an index and a reader,
   // nor is reading in the bytes into memory necessarily the best thing
   // to be doing, but this is fine for small files and where efficiency

--- a/examples/test-examples.js
+++ b/examples/test-examples.js
@@ -46,21 +46,24 @@ runExample('round-trip').then(({ stdout, stderr }) => {
   await runExample('dump-car', ['../test/go.car']).then(async ({ stdout, stderr }) => {
     assert.strictEqual(stderr, '')
     assert.strictEqual(stdout,
-`bafyreihyrpefhacm6kkp4ql6j6udakdit7g3dmkzfriqfykhjw6cad5lrm [dag-cbor]
+`Version: 1
+Roots: [bafyreihyrpefhacm6kkp4ql6j6udakdit7g3dmkzfriqfykhjw6cad5lrm, bafyreidj5idub6mapiupjwjsyyxhyhedxycv4vihfsicm2vt46o7morwlm]
+Blocks:
+#1 bafyreihyrpefhacm6kkp4ql6j6udakdit7g3dmkzfriqfykhjw6cad5lrm [dag-cbor]
 '{"link":{"/":"QmNX6Tffavsya4xgBi2VJQnSuqy9GsxongxZZ9uZBqp16d"},"name":"blip"}'
-QmNX6Tffavsya4xgBi2VJQnSuqy9GsxongxZZ9uZBqp16d [dag-pb]
+#2 QmNX6Tffavsya4xgBi2VJQnSuqy9GsxongxZZ9uZBqp16d [dag-pb]
 '{"Links":[{"Hash":{"/":"bafkreifw7plhl6mofk6sfvhnfh64qmkq73oeqwl6sloru6rehaoujituke"},"Name":"bear","Tsize":4},{"Hash":{"/":"QmWXZxVQ9yZfhQxLD35eDR8LiMRsYtHxYqTFCBbJoiJVys"},"Name":"second","Tsize":149}]}'
-bafkreifw7plhl6mofk6sfvhnfh64qmkq73oeqwl6sloru6rehaoujituke [raw]
+#3 bafkreifw7plhl6mofk6sfvhnfh64qmkq73oeqwl6sloru6rehaoujituke [raw]
 '{"/":{"bytes":"Y2NjYw"}}'
-QmWXZxVQ9yZfhQxLD35eDR8LiMRsYtHxYqTFCBbJoiJVys [dag-pb]
+#4 QmWXZxVQ9yZfhQxLD35eDR8LiMRsYtHxYqTFCBbJoiJVys [dag-pb]
 '{"Links":[{"Hash":{"/":"bafkreiebzrnroamgos2adnbpgw5apo3z4iishhbdx77gldnbk57d4zdio4"},"Name":"dog","Tsize":4},{"Hash":{"/":"QmdwjhxpxzcMsR3qUuj7vUL8pbA7MgR3GAxWi2GLHjsKCT"},"Name":"first","Tsize":51}]}'
-bafkreiebzrnroamgos2adnbpgw5apo3z4iishhbdx77gldnbk57d4zdio4 [raw]
+#5 bafkreiebzrnroamgos2adnbpgw5apo3z4iishhbdx77gldnbk57d4zdio4 [raw]
 '{"/":{"bytes":"YmJiYg"}}'
-QmdwjhxpxzcMsR3qUuj7vUL8pbA7MgR3GAxWi2GLHjsKCT [dag-pb]
+#6 QmdwjhxpxzcMsR3qUuj7vUL8pbA7MgR3GAxWi2GLHjsKCT [dag-pb]
 '{"Links":[{"Hash":{"/":"bafkreidbxzk2ryxwwtqxem4l3xyyjvw35yu4tcct4cqeqxwo47zhxgxqwq"},"Name":"cat","Tsize":4}]}'
-bafkreidbxzk2ryxwwtqxem4l3xyyjvw35yu4tcct4cqeqxwo47zhxgxqwq [raw]
+#7 bafkreidbxzk2ryxwwtqxem4l3xyyjvw35yu4tcct4cqeqxwo47zhxgxqwq [raw]
 '{"/":{"bytes":"YWFhYQ"}}'
-bafyreidj5idub6mapiupjwjsyyxhyhedxycv4vihfsicm2vt46o7morwlm [dag-cbor]
+#8 bafyreidj5idub6mapiupjwjsyyxhyhedxycv4vihfsicm2vt46o7morwlm [dag-cbor]
 '{"link":null,"name":"limbo"}'
 `)
     assert.strictEqual((await Promise.all(goCarCids.map((c) => stat(c)))).map((s) => s.isFile()).filter(Boolean).length, goCarCids.length)

--- a/examples/test-examples.js
+++ b/examples/test-examples.js
@@ -67,6 +67,12 @@ bafyreidj5idub6mapiupjwjsyyxhyhedxycv4vihfsicm2vt46o7morwlm [dag-cbor]
     await cleanGoCarDump()
     console.log('\u001b[32m✔\u001b[39m [example] dump-car ../test/go.car')
   })
+}).then(async () => {
+  await runExample('car-to-fixture', ['../test/go.car']).then(({ stdout, stderr }) => {
+    assert.strictEqual(stderr, '')
+    assert.strictEqual(stdout, '{"blocks":[{"blockLength":55,"blockOffset":137,"cid":{"/":"bafyreihyrpefhacm6kkp4ql6j6udakdit7g3dmkzfriqfykhjw6cad5lrm"},"content":{"link":{"/":"QmNX6Tffavsya4xgBi2VJQnSuqy9GsxongxZZ9uZBqp16d"},"name":"blip"},"length":92,"offset":100},{"blockLength":97,"blockOffset":228,"cid":{"/":"QmNX6Tffavsya4xgBi2VJQnSuqy9GsxongxZZ9uZBqp16d"},"content":{"Links":[{"Hash":{"/":"bafkreifw7plhl6mofk6sfvhnfh64qmkq73oeqwl6sloru6rehaoujituke"},"Name":"bear","Tsize":4},{"Hash":{"/":"QmWXZxVQ9yZfhQxLD35eDR8LiMRsYtHxYqTFCBbJoiJVys"},"Name":"second","Tsize":149}]},"length":133,"offset":192},{"blockLength":4,"blockOffset":362,"cid":{"/":"bafkreifw7plhl6mofk6sfvhnfh64qmkq73oeqwl6sloru6rehaoujituke"},"content":{"/":{"bytes":"Y2NjYw"}},"length":41,"offset":325},{"blockLength":94,"blockOffset":402,"cid":{"/":"QmWXZxVQ9yZfhQxLD35eDR8LiMRsYtHxYqTFCBbJoiJVys"},"content":{"Links":[{"Hash":{"/":"bafkreiebzrnroamgos2adnbpgw5apo3z4iishhbdx77gldnbk57d4zdio4"},"Name":"dog","Tsize":4},{"Hash":{"/":"QmdwjhxpxzcMsR3qUuj7vUL8pbA7MgR3GAxWi2GLHjsKCT"},"Name":"first","Tsize":51}]},"length":130,"offset":366},{"blockLength":4,"blockOffset":533,"cid":{"/":"bafkreiebzrnroamgos2adnbpgw5apo3z4iishhbdx77gldnbk57d4zdio4"},"content":{"/":{"bytes":"YmJiYg"}},"length":41,"offset":496},{"blockLength":47,"blockOffset":572,"cid":{"/":"QmdwjhxpxzcMsR3qUuj7vUL8pbA7MgR3GAxWi2GLHjsKCT"},"content":{"Links":[{"Hash":{"/":"bafkreidbxzk2ryxwwtqxem4l3xyyjvw35yu4tcct4cqeqxwo47zhxgxqwq"},"Name":"cat","Tsize":4}]},"length":82,"offset":537},{"blockLength":4,"blockOffset":656,"cid":{"/":"bafkreidbxzk2ryxwwtqxem4l3xyyjvw35yu4tcct4cqeqxwo47zhxgxqwq"},"content":{"/":{"bytes":"YWFhYQ"}},"length":41,"offset":619},{"blockLength":18,"blockOffset":697,"cid":{"/":"bafyreidj5idub6mapiupjwjsyyxhyhedxycv4vihfsicm2vt46o7morwlm"},"content":{"link":null,"name":"limbo"},"length":55,"offset":660}],"header":{"roots":[{"/":"bafyreihyrpefhacm6kkp4ql6j6udakdit7g3dmkzfriqfykhjw6cad5lrm"},{"/":"bafyreidj5idub6mapiupjwjsyyxhyhedxycv4vihfsicm2vt46o7morwlm"}],"version":1}}\n')
+    console.log('\u001b[32m✔\u001b[39m [example] car-to-fixture ../test/go.car')
+  })
 }).catch((err) => {
   console.error(err.stack)
   process.exit(1)


### PR DESCRIPTION
Some improvements that have been languishing in #30 that I'd like to get into master. `car-to-fixture.js` is pretty nice, and the improvements to `dump-car.js` are useful too (`--inspect` is new here but should be very helpful for inspecting a CAR).