### PR TITLE
fix(types): don't use `unknown` error type

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -14,6 +14,7 @@
     "strictPropertyInitialization": true,
     "strictBindCallApply": true,
     "strict": true,
+    "useUnknownInCatchVariables": false,
     "alwaysStrict": true,
     "esModuleInterop": true,
     "target": "ES2018",


### PR DESCRIPTION
TS 4.4 now treats caught errors as `unknown` if `strict` is enabled, so turn
that off and we get back to `any`, which is fine for our purposes.