### PR TITLE
fix: don't return promise in async function

### DIFF
--- a/lib/encoder.js
+++ b/lib/encoder.js
@@ -59,7 +59,7 @@ function createEncoder (writer) {
      * @returns {Promise<void>}
      */
     async close () {
-      return writer.end()
+      await writer.end()
       /* c8 ignore next 2 */
       // Node.js 12 c8 bug
     }

--- a/lib/iterator-channel.js
+++ b/lib/iterator-channel.js
@@ -52,7 +52,7 @@ export function create () {
       ended = true
       const drainer = makeDrainer()
       outWaitResolver()
-      return drainer
+      await drainer
       /* c8 ignore next 2 */
       // Node.js 12 c8 bug
     }


### PR DESCRIPTION
I _think_ this might be responsible for weird failures I'm getting @ https://github.com/ipld/js-bitcoin/pull/3, e.g. https://github.com/ipld/js-bitcoin/runs/6157987168?check_suite_focus=true

These two `async` functions are returning `Promise`s rather than awaiting them. So callers that `await` on these two won't get the full resolution of the `Promise` but the `Promise` itself, which they would have to `await` on again.. `await (await writer.end())`.

Timing is everything, there's a good chance that it gets sorted out before you care about it, but for small, quick writes, like I'm dealing with, perhaps not.