### PR TITLE
fix: address Typescript's TS2463 by layering optional param destructuring

### DIFF
--- a/lib/buffer-writer.js
+++ b/lib/buffer-writer.js
@@ -78,7 +78,8 @@ class CarBufferWriter {
  * @param {CID} root
  * @param {{resize?:boolean}} [options]
  */
-export const addRoot = (writer, root, { resize = false } = {}) => {
+export const addRoot = (writer, root, options = {}) => {
+  const { resize = false } = options
   const { bytes, headerSize, byteOffset, roots } = writer
   writer.roots.push(root)
   const size = headerLength(writer)
@@ -137,7 +138,8 @@ export const addBlock = (writer, { cid, bytes }) => {
  * @param {object} [options]
  * @param {boolean} [options.resize]
  */
-export const close = (writer, { resize = false } = {}) => {
+export const close = (writer, options = {}) => {
+  const { resize = false } = options
   const { roots, bytes, byteOffset, headerSize } = writer
 
   const headerBytes = CBOR.encode({ version: 1, roots })
@@ -266,15 +268,13 @@ export const estimateHeaderLength = (rootCount, rootByteLength = 36) =>
  * @param {number} [options.headerSize]
  * @returns {CarBufferWriter}
  */
-export const createWriter = (
-  buffer,
-  {
+export const createWriter = (buffer, options = {}) => {
+  const {
     roots = [],
     byteOffset = 0,
     byteLength = buffer.byteLength,
     headerSize = headerLength({ roots })
-  } = {}
-) => {
+  } = options
   const bytes = new Uint8Array(buffer, byteOffset, byteLength)
 
   const writer = new CarBufferWriter(bytes, headerSize)

--- a/package.json
+++ b/package.json
@@ -83,7 +83,7 @@
     "mocha": "^10.0.0",
     "polendina": "~3.1.0",
     "standard": "^17.0.0",
-    "typescript": "~4.7.2"
+    "typescript": "~4.8.2"
   },
   "standard": {
     "ignore": [


### PR DESCRIPTION
Builds off and fixes #92 that comes with a new TypeScript error condition that's failing—within a minor release, again. Reinforcing how important it is to `~` TypeScript rather than `^` it!