### PR TITLE
fix: address updated varint typedefs

### DIFF
--- a/examples/package.json
+++ b/examples/package.json
@@ -17,7 +17,7 @@
   "dependencies": {
     "@ipld/car": "file:..",
     "@ipld/dag-cbor": "^8.0.0",
-    "@ipld/dag-json": "^8.0.0",
+    "@ipld/dag-json": "^9.0.1",
     "@ipld/dag-pb": "^3.0.0",
     "@multiformats/blake2": "^1.0.1",
     "@types/varint": "^6.0.0",

--- a/examples/package.json
+++ b/examples/package.json
@@ -18,7 +18,7 @@
     "@ipld/car": "file:..",
     "@ipld/dag-cbor": "^8.0.0",
     "@ipld/dag-json": "^8.0.0",
-    "@ipld/dag-pb": "^2.0.2",
+    "@ipld/dag-pb": "^3.0.0",
     "@multiformats/blake2": "^1.0.1",
     "@types/varint": "^6.0.0",
     "multiformats": "^10.0.0",

--- a/src/decoder.js
+++ b/src/decoder.js
@@ -33,7 +33,7 @@ async function readVarint (reader) {
     throw new Error('Unexpected end of data')
   }
   const i = varint.decode(bytes)
-  reader.seek(varint.decode.bytes)
+  reader.seek(/** @type {number} */(varint.decode.bytes))
   return i
   /* c8 ignore next 2 */
   // Node.js 12 c8 bug
@@ -117,9 +117,9 @@ async function readMultihash (reader) {
 
   const bytes = await reader.upTo(8)
   varint.decode(bytes) // code
-  const codeLength = varint.decode.bytes
+  const codeLength = /** @type {number} */(varint.decode.bytes)
   const length = varint.decode(bytes.subarray(varint.decode.bytes))
-  const lengthLength = varint.decode.bytes
+  const lengthLength = /** @type {number} */(varint.decode.bytes)
   const mhLength = codeLength + lengthLength + length
   const multihash = await reader.exactly(mhLength)
   reader.seek(mhLength)


### PR DESCRIPTION
`.bytes` will always be a number in the places we use it, just after a successful decode, so forcing the type here should be fine

also pulls in the dependabot updates for examples/package.json