### PR TITLE
fix: update release config

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # @ipld/car
 
 [![codecov](https://img.shields.io/codecov/c/github/ipld/js-car.svg?style=flat-square)](https://codecov.io/gh/ipld/js-car)
-[![CI](https://img.shields.io/github/workflow/status/ipld/js-car/test%20&%20maybe%20release/master?style=flat-square)](https://github.com/ipld/js-car/actions/workflows/js-test-and-release.yml)
+[![CI](https://img.shields.io/github/actions/workflow/status/ipld/js-car/js-test-and-release.yml?branch=master\&style=flat-square)](https://github.com/ipld/js-car/actions/workflows/js-test-and-release.yml?query=branch%3Amaster)
 
 > Content Addressable aRchive format reader and writer
 

--- a/package.json
+++ b/package.json
@@ -90,6 +90,91 @@
       "sourceType": "module"
     }
   },
+  "release": {
+    "branches": [
+      "master"
+    ],
+    "plugins": [
+      [
+        "@semantic-release/commit-analyzer",
+        {
+          "preset": "conventionalcommits",
+          "releaseRules": [
+            {
+              "breaking": true,
+              "release": "major"
+            },
+            {
+              "revert": true,
+              "release": "patch"
+            },
+            {
+              "type": "feat",
+              "release": "minor"
+            },
+            {
+              "type": "fix",
+              "release": "patch"
+            },
+            {
+              "type": "docs",
+              "release": "patch"
+            },
+            {
+              "type": "test",
+              "release": "patch"
+            },
+            {
+              "type": "deps",
+              "release": "patch"
+            },
+            {
+              "scope": "no-release",
+              "release": false
+            }
+          ]
+        }
+      ],
+      [
+        "@semantic-release/release-notes-generator",
+        {
+          "preset": "conventionalcommits",
+          "presetConfig": {
+            "types": [
+              {
+                "type": "feat",
+                "section": "Features"
+              },
+              {
+                "type": "fix",
+                "section": "Bug Fixes"
+              },
+              {
+                "type": "chore",
+                "section": "Trivial Changes"
+              },
+              {
+                "type": "docs",
+                "section": "Documentation"
+              },
+              {
+                "type": "deps",
+                "section": "Dependencies"
+              },
+              {
+                "type": "test",
+                "section": "Tests"
+              }
+            ]
+          }
+        }
+      ],
+      "@semantic-release/changelog",
+      "@semantic-release/npm",
+      "@semantic-release/github",
+      "@semantic-release/git"
+    ]
+  },
   "scripts": {
     "clean": "aegir clean",
     "lint": "aegir lint",
@@ -123,14 +208,6 @@
     "aegir": "^37.5.6",
     "jsdoc4readme": "^1.4.0"
   },
-  "directories": {
-    "test": "test"
-  },
-  "standard": {
-    "ignore": [
-      "dist"
-    ]
-  },
   "browser": {
     "./src/index.js": "./src/index-browser.js",
     "./src/index-reader.js": "./src/index-reader-browser.js",
@@ -139,5 +216,13 @@
     "fs": false,
     "util": false,
     "stream": false
+  },
+  "directories": {
+    "test": "test"
+  },
+  "standard": {
+    "ignore": [
+      "dist"
+    ]
   }
 }


### PR DESCRIPTION
Adds standard semantic release config so prefixes like `deps:` trigger a release.

Also fixes readme CI badge.