### PR TITLE
feat: expose contentType

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -6,6 +6,9 @@ import { CarWriter } from './writer.js'
 import { CarIndexedReader } from './indexed-reader.js'
 import * as CarBufferWriter from './buffer-writer.js'
 
+// @see https://www.iana.org/assignments/media-types/application/vnd.ipld.car
+export const contentType = 'application/vnd.ipld.car'
+
 export {
   CarReader,
   CarBufferReader,


### PR DESCRIPTION
We found ourselves using a wrong `application/car` content type before we discovered it was a mistake https://github.com/web3-storage/ucanto/issues/269. Change here just exports official
`contentType` for the CAR format so that users of the library can simply reference it and hopefully avoid mistakes we made.