### PR TITLE
feat: add version method to CarWriter

### DIFF
--- a/src/api.ts
+++ b/src/api.ts
@@ -55,6 +55,7 @@ export interface BlockBufferReader {
 export interface BlockWriter {
   put(block: Block): Promise<void>
   close(): Promise<void>
+  version(): number
 }
 
 export interface CarBufferWriter {

--- a/src/coding.ts
+++ b/src/coding.ts
@@ -7,6 +7,8 @@ export interface CarEncoder {
   writeBlock(block: Block): Promise<void>
 
   close(): Promise<void>
+
+  version(): number
 }
 
 export interface IteratorChannel_Writer<T> {

--- a/src/encoder.js
+++ b/src/encoder.js
@@ -8,6 +8,8 @@ import varint from 'varint'
  * @typedef {import('./coding').IteratorChannel_Writer<Uint8Array>} IteratorChannel_Writer
  */
 
+const CAR_V1_VERSION = 1
+
 /**
  * Create a header from an array of roots.
  *
@@ -15,7 +17,7 @@ import varint from 'varint'
  * @returns {Uint8Array}
  */
 export function createHeader (roots) {
-  const headerBytes = dagCborEncode({ version: 1, roots })
+  const headerBytes = dagCborEncode({ version: CAR_V1_VERSION, roots })
   const varintBytes = varint.encode(headerBytes.length)
   const header = new Uint8Array(varintBytes.length + headerBytes.length)
   header.set(varintBytes, 0)
@@ -60,6 +62,13 @@ function createEncoder (writer) {
      */
     async close () {
       await writer.end()
+    },
+
+    /**
+     * @returns {number}
+     */
+    version () {
+      return CAR_V1_VERSION
     }
   }
 }

--- a/src/writer-browser.js
+++ b/src/writer-browser.js
@@ -105,6 +105,15 @@ export class CarWriter {
   }
 
   /**
+   * Returns the version number of the CAR file being written
+   *
+   * @returns {number}
+   */
+  version () {
+    return this._encoder.version()
+  }
+
+  /**
    * Create a new CAR writer "channel" which consists of a
    * `{ writer:CarWriter, out:AsyncIterable<Uint8Array> }` pair.
    *

--- a/test/test-writer.spec.js
+++ b/test/test-writer.spec.js
@@ -224,6 +224,13 @@ describe('CarWriter', () => {
     assert.strictEqual(toHex(bytes).substring(0, expectedStart.length), expectedStart)
   })
 
+  it('version', async () => {
+    const { writer } = CarWriter.create(roots)
+
+    // v1 only
+    assert.equal(writer.version(), 1)
+  })
+
   it('no roots', async () => {
     const { writer, out } = CarWriter.create()
     const collection = collector(out)


### PR DESCRIPTION
The `version()` method retrieves the version number from the underlying encoder.

Fixes #161