### PR TITLE
make reader lazy on fs.read to run ignore polyfill

### DIFF
--- a/src/promise-fs-opts.js
+++ b/src/promise-fs-opts.js
@@ -1,0 +1,42 @@
+import fs from 'fs'
+import { promisify } from 'util'
+
+export { fs }
+
+/**
+ * @description not happy with typing here, but it's needed for the `promisify(fs.read)` function.
+ * @type {any}
+ */
+let _fsReadFn
+/**
+ * @description This function is needed not to initialize the `fs.read` on load time. To run in cf workers without polyfill.
+ * @param {number} fd
+ * @param {Uint8Array} buffer
+ * @param {number} offset
+ * @param {number} length
+ * @param {number} position
+ * @returns {Promise<{ bytesRead: number, buffer: Uint8Array }>}
+ */
+export function fsread (fd, buffer, offset, length, position) {
+  _fsReadFn = _fsReadFn || promisify(fs.read)
+  return _fsReadFn(fd, buffer, offset, length, position)
+}
+
+/**
+ * @description not happy with typing here, but it's needed for the `promisify(fs.write)` function.
+ * @type {any}
+ */
+let _fsWriteFn
+/**
+ * @description This function is needed not to initialize the `fs.write` on load time. To run in cf workers without polyfill.
+ * @param {number} fd
+ * @param {Uint8Array} buffer
+ * @param {number} offset
+ * @param {number} length
+ * @param {number} position
+ * @returns {Promise<{ bytesRead: number, buffer: Uint8Array }>}
+ */
+export function fswrite (fd, buffer, offset, length, position) {
+  _fsWriteFn = _fsWriteFn || promisify(fs.write)
+  return _fsWriteFn(fd, buffer, offset, length, position)
+}

--- a/src/promise-fs-opts.js
+++ b/src/promise-fs-opts.js
@@ -1,10 +1,11 @@
 import fs from 'fs'
 import { promisify } from 'util'
 
-export { fs }
+const hasFS = Boolean(fs)
+
+export { hasFS }
 
 /**
- * @description not happy with typing here, but it's needed for the `promisify(fs.read)` function.
  * @type {any}
  */
 let _fsReadFn
@@ -18,12 +19,13 @@ let _fsReadFn
  * @returns {Promise<{ bytesRead: number, buffer: Uint8Array }>}
  */
 export function fsread (fd, buffer, offset, length, position) {
-  _fsReadFn = _fsReadFn || promisify(fs.read)
+  if (!_fsReadFn) {
+    _fsReadFn = promisify(fs.read)
+  }
   return _fsReadFn(fd, buffer, offset, length, position)
 }
 
 /**
- * @description not happy with typing here, but it's needed for the `promisify(fs.write)` function.
  * @type {any}
  */
 let _fsWriteFn
@@ -37,6 +39,8 @@ let _fsWriteFn
  * @returns {Promise<{ bytesRead: number, buffer: Uint8Array }>}
  */
 export function fswrite (fd, buffer, offset, length, position) {
-  _fsWriteFn = _fsWriteFn || promisify(fs.write)
+  if (!_fsWriteFn) {
+    _fsWriteFn = promisify(fs.write)
+  }
   return _fsWriteFn(fd, buffer, offset, length, position)
 }

--- a/src/reader.js
+++ b/src/reader.js
@@ -8,7 +8,24 @@ import { CarReader as BrowserCarReader } from './reader-browser.js'
  * @typedef {import('./api').CarReader} CarReaderIface
  */
 
-const fsread = promisify(fs.read)
+/**
+ * @description not happy with typing here, but it's needed for the `promisify(fs.read)` function.
+ * @type {any}
+ */
+let _fsReadFn
+/**
+ * @description This function is needed not to initialize the `fs.read` on load time. To run in cf workers without polyfill.
+ * @param {number} fd
+ * @param {Uint8Array} buffer
+ * @param {number} offset
+ * @param {number} length
+ * @param {number} position
+ * @returns {Promise<{ bytesRead: number, buffer: Uint8Array }>}
+ */
+function fsread (fd, buffer, offset, length, position) {
+  _fsReadFn = _fsReadFn || promisify(fs.read)
+  return _fsReadFn(fd, buffer, offset, length, position)
+}
 
 /**
  * @class
@@ -53,4 +70,4 @@ export class CarReader extends BrowserCarReader {
   }
 }
 
-export const __browser = false
+export const __browser = !fs

--- a/src/reader.js
+++ b/src/reader.js
@@ -1,10 +1,11 @@
-import { fsread, fs } from './promise-fs-opts.js'
+import { fsread, hasFS } from './promise-fs-opts.js'
 import { CarReader as BrowserCarReader } from './reader-browser.js'
 
 /**
  * @typedef {import('./api').Block} Block
  * @typedef {import('./api').BlockIndex} BlockIndex
  * @typedef {import('./api').CarReader} CarReaderIface
+ * @typedef {import('fs').promises.FileHandle} FileHandle
  */
 
 /**
@@ -24,7 +25,7 @@ export class CarReader extends BrowserCarReader {
    * @async
    * @static
    * @memberof CarReader
-   * @param {fs.promises.FileHandle | number} fd - A file descriptor from the
+   * @param {FileHandle | number} fd - A file descriptor from the
    * Node.js `fs` module. Either an integer, from `fs.open()` or a `FileHandle`
    * from `fs.promises.open()`.
    * @param {BlockIndex} blockIndex - An index pointing to the location of the
@@ -50,4 +51,4 @@ export class CarReader extends BrowserCarReader {
   }
 }
 
-export const __browser = !fs
+export const __browser = !hasFS

--- a/src/reader.js
+++ b/src/reader.js
@@ -1,5 +1,4 @@
-import fs from 'fs'
-import { promisify } from 'util'
+import { fsread, fs } from './promise-fs-opts.js'
 import { CarReader as BrowserCarReader } from './reader-browser.js'
 
 /**
@@ -7,25 +6,6 @@ import { CarReader as BrowserCarReader } from './reader-browser.js'
  * @typedef {import('./api').BlockIndex} BlockIndex
  * @typedef {import('./api').CarReader} CarReaderIface
  */
-
-/**
- * @description not happy with typing here, but it's needed for the `promisify(fs.read)` function.
- * @type {any}
- */
-let _fsReadFn
-/**
- * @description This function is needed not to initialize the `fs.read` on load time. To run in cf workers without polyfill.
- * @param {number} fd
- * @param {Uint8Array} buffer
- * @param {number} offset
- * @param {number} length
- * @param {number} position
- * @returns {Promise<{ bytesRead: number, buffer: Uint8Array }>}
- */
-function fsread (fd, buffer, offset, length, position) {
-  _fsReadFn = _fsReadFn || promisify(fs.read)
-  return _fsReadFn(fd, buffer, offset, length, position)
-}
 
 /**
  * @class

--- a/src/writer.js
+++ b/src/writer.js
@@ -1,11 +1,12 @@
 import { readHeader, chunkReader } from './decoder.js'
 import { createHeader } from './encoder.js'
-import { fsread, fswrite, fs } from './promise-fs-opts.js'
+import { fsread, fswrite, hasFS } from './promise-fs-opts.js'
 import { CarWriter as BrowserCarWriter } from './writer-browser.js'
 
 /**
  * @typedef {import('multiformats/cid').CID} CID
  * @typedef {import('./api').BlockWriter} BlockWriter
+ * @typedef {import('fs').promises.FileHandle} FileHandle
  */
 
 /**
@@ -31,7 +32,7 @@ export class CarWriter extends BrowserCarWriter {
    * @async
    * @static
    * @memberof CarWriter
-   * @param {fs.promises.FileHandle | number} fd - A file descriptor from the
+   * @param {FileHandle | number} fd - A file descriptor from the
    * Node.js `fs` module. Either an integer, from `fs.open()` or a `FileHandle`
    * from `fs.promises.open()`.
    * @param {CID[]} roots - A new list of roots to replace the existing list in
@@ -77,4 +78,4 @@ export class CarWriter extends BrowserCarWriter {
   }
 }
 
-export const __browser = !fs
+export const __browser = !hasFS

--- a/src/writer.js
+++ b/src/writer.js
@@ -1,11 +1,7 @@
-import fs from 'fs'
-import { promisify } from 'util'
 import { readHeader, chunkReader } from './decoder.js'
 import { createHeader } from './encoder.js'
+import { fsread, fswrite, fs } from './promise-fs-opts.js'
 import { CarWriter as BrowserCarWriter } from './writer-browser.js'
-
-const fsread = promisify(fs.read)
-const fswrite = promisify(fs.write)
 
 /**
  * @typedef {import('multiformats/cid').CID} CID
@@ -81,4 +77,4 @@ export class CarWriter extends BrowserCarWriter {
   }
 }
 
-export const __browser = false
+export const __browser = !fs


### PR DESCRIPTION
Hi,

I have a problem with running @ipld/car in Cloudflare workers.
In a lovely world the internal esbuild of wrangler should pick the browser implementation.
But the reality is that wrangler/esbuild picks the node implementation and provides a polyfill for the node
imports that will cause:
```
const fsread = promisify(fs.read)
```
this error:
```
Cannot read properties of undefined (reading 'read')
```
So I made it lazy and set __browser.